### PR TITLE
update from upstream

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -141,6 +141,8 @@ branches:
             app_id: 15368
           - context: "codecov/project"
             app_id: 254
+      # Commits pushed to matching refs must have verified signatures.
+      required_signatures: false
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       enforce_admins: null
       # Prevent merge commits from being pushed to matching branches

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".vscode/rust-prettifier-for-lldb"]
+	path = .vscode/rust-prettifier-for-lldb
+	url = https://github.com/cmrschwarz/rust-prettifier-for-lldb

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 .git
-.github/actions/
+.mypy_cache
+.vscode/rust-prettifier-for-lldb
 CHANGELOG.md
 profiling
 reports

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,8 +21,8 @@
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,bond_rs=TRACE"
             },
-            "internalConsoleOptions": "openOnSessionStart",
-            "terminal": "console"
+            "internalConsoleOptions": "neverOpen",
+            "terminal": "integrated"
         },
         {
             "type": "lldb",
@@ -46,8 +46,8 @@
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,bond_rs=TRACE"
             },
-            "internalConsoleOptions": "openOnSessionStart",
-            "terminal": "console"
+            "internalConsoleOptions": "neverOpen",
+            "terminal": "integrated"
         },
         {
             "type": "lldb",
@@ -71,8 +71,8 @@
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,bond_rs=TRACE"
             },
-            "internalConsoleOptions": "openOnSessionStart",
-            "terminal": "console"
+            "internalConsoleOptions": "neverOpen",
+            "terminal": "integrated"
         }
     ]
 }

--- a/.vscode/rust_prettifier_for_lldb.py
+++ b/.vscode/rust_prettifier_for_lldb.py
@@ -1,0 +1,1 @@
+./rust-prettifier-for-lldb/rust_prettifier_for_lldb.py

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,11 @@
 {
-    "debug.internalConsoleOptions": "openOnSessionStart",
+    "debug.internalConsoleOptions": "neverOpen",
+    "lldb.launch.terminal": "integrated",
+    "lldb.launch.expressions": "simple",
+    "lldb.launch.preRunCommands": [
+        "command script import ${workspaceFolder}/.vscode/rust_prettifier_for_lldb.py"
+    ],
     "prettier.configPath": "./.prettierrc.cjs",
-    "rust-analyzer.debug.engineSettings": {
-        "lldb": {
-            "internalConsoleOptions": "openOnSessionStart",
-            "terminal": "console"
-        }
-    },
-    "rust-analyzer.debug.openDebugPane": true,
     "rust-analyzer.runnables.extraEnv": {
         "RUST_LOG": "DEBUG,bond_rs=TRACE"
     }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ perf = "warn"
 style = "warn"
 suspicious = "warn"
 
+# this one is debatable. continue is used in places to be explicit, and to guard against
+# issues when refactoring
+needless_continue = { level = "allow", priority = 127 }
 # this one causes confusion when combining variables (`foo`) and
 # dereferenced variables (`foo.bar`). The latter cannot be inlined
 # so we don't inline anything
@@ -31,9 +34,6 @@ uninlined-format-args = { level = "allow", priority = 127 }
 [lints.rust]
 let_underscore_drop = { level = "deny", priority = 127 }
 non_ascii_idents = { level = "deny", priority = 127 }
-
-[features]
-coverage = []
 
 [dependencies]
 anyhow = "1.0.98"


### PR DESCRIPTION
- **chore(deps): update rust docker tag to v1.85.1**
- **chore(deps): update rust to v1.85.1**
- **chore(deps): update rust:1.85.1 docker digest to 12ed23b**
- **chore(deps): update rust:1.85.1 docker digest to e51d026**
- **chore(deps): update actions/cache action to v4.2.3**
- **chore(deps): update actions/download-artifact action to v4.2.1**
- **chore(deps): update actions/upload-artifact action to v4.6.2**
- **chore(deps): update github/codeql-action action to v3.28.12**
- **chore(deps): update returntocorp/semgrep docker tag to v1.114.0**
- **chore(deps): update github/codeql-action action to v3.28.13**
- **chore(deps): update returntocorp/semgrep docker tag to v1.116.0**
- **chore(deps): update dependency prettier-plugin-sh to v0.16.0**
- **chore(deps): lock file maintenance**
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.19.0**
- **chore(deps): update rui314/setup-mold digest to e16410e**
- **chore(deps): update returntocorp/semgrep docker tag to v1.117.0**
- **chore: clippy 1.86 fixes**
- **chore(deps): update rust docker tag to v1.86.0**
- **chore(deps): update rust to v1.86.0**
- **chore: disable required signatures**
- **chore(deps): update rust:1.86.0 docker digest to 563b33d**
- **chore(deps): update dependency prettier-plugin-sh to v0.16.1**
- **chore(deps): lock file maintenance**
- **chore(deps): update github/codeql-action action to v3.28.14**
- **chore(deps): update github/codeql-action action to v3.28.15**
- **chore(deps): update rust:1.86.0 docker digest to 2494472**
- **chore(deps): update rust:1.86.0 docker digest to 6a6dda6**
- **chore(deps): update dependency prettier-plugin-sh to v0.17.0**
- **chore(deps): update npm to >=11.3.0**
- **chore(deps): update rust:1.86.0 docker digest to 9fdf93f**
- **chore(deps): update rust:1.86.0 docker digest to 7b65306**
- **chore(deps): update returntocorp/semgrep docker tag to v1.118.0**
- **chore(deps): update dependency prettier-plugin-sh to v0.17.1**
- **chore(deps): update dependency prettier-plugin-sh to v0.17.2**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to a87c2e8**
- **chore(deps): lock file maintenance**
- **chore(deps): update actions/setup-node action to v4.4.0**
- **chore(deps): update codecov/codecov-action action to v5.4.2**
- **chore(deps): update returntocorp/semgrep docker tag to v1.119.0**
- **chore(deps): update softprops/action-gh-release action to v2.2.2**
- **chore(deps): lock file maintenance**
- **fix: start tracking lldb debug helper**
- **chore(deps): update returntocorp/semgrep docker tag to v1.120.0**
- **chore(deps): update github/codeql-action action to v3.28.16**
- **chore(deps): update node.js to v22.15.0**
- **chore(deps): update docker/build-push-action action to v6.16.0**
- **chore(deps): update actions/download-artifact action to v4.3.0**
- **chore: set default debug visualizer**
- **chore: update debug setup**
