### PR TITLE
update from upstream

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -142,6 +142,8 @@ branches:
         checks:
           - context: "All done"
             app_id: 15368
+          - context: "Validate formatting"
+            app_id: 15368
           - context: "codecov/project"
             app_id: 254
       # Commits pushed to matching refs must have verified signatures.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-name: Build
+name: CI
 
 on:
   push:
@@ -9,14 +9,14 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-
 concurrency:
   # each new commit to a PR runs this workflow
   # so we need to avoid a long running older one from overwriting the "pr-<number>-latest"
   group: "${{ github.workflow }} @ ${{ github.ref_name }}"
   cancel-in-progress: true
+
+permissions:
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -473,7 +473,8 @@ jobs:
     outputs:
       application_name: ${{ steps.variables.outputs.application_name }}
       description: ${{ steps.variables.outputs.description }}
-      full_image_name: ${{ steps.variables.outputs.full_image_name }}
+      full_image_name_remote_registry: ${{ steps.variables.outputs.full_image_name_remote_registry }}
+      full_image_name_local_registry: ${{ steps.variables.outputs.full_image_name_local_registry }}
       registry: ${{ steps.variables.outputs.registry }}
       unique_tag: ${{ steps.variables.outputs.unique_tag }}
     runs-on: ${{ matrix.runs-on }}
@@ -585,10 +586,15 @@ jobs:
           registry=${registry,,}
           echo "registry=${registry}" >> ${GITHUB_OUTPUT}
 
-          # The full image name, which is the registry, the owner and the repo name
+          # The final full image name, which is the registry, the owner and the repo name
           image_name=${{ env.IMAGE_NAME }}
           image_name=${image_name,,}
-          echo "full_image_name=${registry}/${image_name}" >> ${GITHUB_OUTPUT}
+          echo "full_image_name_remote_registry=${registry}/${image_name}" >> ${GITHUB_OUTPUT}
+
+          # The local registry to which we'll push
+          local_registry=localhost:5000
+          local_registry=${local_registry,,}
+          echo "full_image_name_local_registry=${local_registry}/${image_name}" >> ${GITHUB_OUTPUT}
 
           # The application's description, from Cargo.toml
           description=$(cargo get package.description)
@@ -605,7 +611,7 @@ jobs:
             org.opencontainers.image.revision=${{ github.event.pull_request.base.sha }}-${{ github.event.pull_request.head.sha }}
             org.opencontainers.image.source=${{ github.event.pull_request.html_url }}
             org.opencontainers.image.version=pr-${{ github.event.number }}
-          images: ${{ steps.variables.outputs.full_image_name }}
+          images: ${{ steps.variables.outputs.full_image_name_local_registry }}
           tags: |
             type=raw,value=${{ steps.variables.outputs.unique_tag_arch }}
 
@@ -624,16 +630,14 @@ jobs:
 
       - name: Build Docker image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        env:
-          BUILDX_NO_DEFAULT_ATTESTATIONS: true
         with:
           build-args: |
             APPLICATION_NAME=${{ steps.variables.outputs.application_name }}
           context: .
           # this container is THE PR's artifact, and we will re-tag it
           # once the PR has been accepted
-          cache-from: type=registry,ref=${{ steps.variables.outputs.full_image_name }}:buildcache-${{ runner.arch }}-${{ steps.variables.outputs.application_name }}-${{ matrix.platform }}
-          cache-to: type=registry,ref=${{ steps.variables.outputs.full_image_name }}:buildcache-${{ runner.arch }}-${{ steps.variables.outputs.application_name }}-${{ matrix.platform }},mode=max
+          cache-from: type=registry,ref=${{ steps.variables.outputs.full_image_name_remote_registry }}:buildcache-${{ runner.arch }}-${{ steps.variables.outputs.application_name }}-${{ matrix.platform }}
+          cache-to: type=registry,ref=${{ steps.variables.outputs.full_image_name_remote_registry }}:buildcache-${{ runner.arch }}-${{ steps.variables.outputs.application_name }}-${{ matrix.platform }},mode=max
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=oci,dest=/tmp/${{ steps.variables.outputs.unique_tag_arch }}.tar
           platforms: linux/${{ matrix.platform }}
@@ -652,7 +656,14 @@ jobs:
   docker-publish:
     name: Publish Docker container
     runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:3@sha256:1fc7de654f2ac1247f0b67e8a459e273b0993be7d2beda1f3f56fbf1001ed3e7
+        ports:
+          - 5000:5000
     permissions:
+      attestations: write
+      id-token: write
       packages: write
     needs:
       - cargo-build
@@ -691,12 +702,12 @@ jobs:
             org.opencontainers.image.revision=${{ github.event.pull_request.base.sha }}-${{ github.event.pull_request.head.sha }}
             org.opencontainers.image.source=${{ github.event.pull_request.html_url }}
             org.opencontainers.image.version=pr-${{ github.event.number }}
-          images: ${{ needs.docker-build.outputs.full_image_name }}
+          images: ${{ needs.docker-build.outputs.full_image_name_local_registry }}
           tags: |
             type=raw,value=${{ needs.docker-build.outputs.unique_tag }}
             type=ref,event=pr,suffix=-latest
 
-      - name: Download artifact
+      - name: Download artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         id: artifact
         with:
@@ -709,30 +720,32 @@ jobs:
         working-directory: ${{ steps.artifact.outputs.download-path }}
         run: |
           docker load --input ./${{ needs.docker-build.outputs.unique_tag }}-amd64.tar
-          docker push ${{ needs.docker-build.outputs.full_image_name }}:${{ needs.docker-build.outputs.unique_tag }}-amd64
+          echo "Pushing amd64:"
+          docker push ${{ needs.docker-build.outputs.full_image_name_local_registry }}:${{ needs.docker-build.outputs.unique_tag }}-amd64
 
           docker load --input ./${{ needs.docker-build.outputs.unique_tag }}-arm64.tar
-          docker push ${{ needs.docker-build.outputs.full_image_name }}:${{ needs.docker-build.outputs.unique_tag }}-arm64
+          echo "Pushing arm64:"
+          docker push ${{ needs.docker-build.outputs.full_image_name_local_registry }}:${{ needs.docker-build.outputs.unique_tag }}-arm64
 
       - name: Create multiplatform image
         shell: bash
         run: |
-          new_labels=()
-          while IFS= read -r label; do
-            new_labels+=(--annotation)
-            new_labels+=("index:${label}")
-          done <<< "${{ steps.meta.outputs.labels }}"
-
           new_tags=()
           while IFS= read -r tag; do
             new_tags+=(--tag)
             new_tags+=(${tag})
           done <<< "${{ steps.meta.outputs.tags }}"
 
+          new_labels=()
+          while IFS= read -r label; do
+            new_labels+=(--annotation)
+            new_labels+=("index:${label}")
+          done <<< "${{ steps.meta.outputs.labels }}"
+
           # merge the amd64 and arm64 containers in a new multiplatform one
           docker buildx imagetools create "${new_tags[@]}" "${new_labels[@]}" \
-            ${{ needs.docker-build.outputs.full_image_name }}:${{ needs.docker-build.outputs.unique_tag }}-amd64 \
-            ${{ needs.docker-build.outputs.full_image_name }}:${{ needs.docker-build.outputs.unique_tag }}-arm64
+            ${{ needs.docker-build.outputs.full_image_name_local_registry }}:${{ needs.docker-build.outputs.unique_tag }}-amd64 \
+            ${{ needs.docker-build.outputs.full_image_name_local_registry }}:${{ needs.docker-build.outputs.unique_tag }}-arm64
 
           for new_tag in $(echo "${{ join(steps.meta.outputs.tags, ' ') }}"); do
             echo "${new_tag}:"
@@ -740,6 +753,33 @@ jobs:
             # empty to get newline
             echo ""
           done
+
+      - name: Get digest of multiplatform image in our local registry
+        shell: bash
+        id: multiplatform_image
+        run: |
+          digest=$(docker buildx imagetools inspect ${{ needs.docker-build.outputs.full_image_name_local_registry }}:${{ needs.docker-build.outputs.unique_tag }} --format "{{json .}}" | jq --raw-output ".manifest.digest")
+
+          echo "digest=${digest}" >> ${GITHUB_OUTPUT}
+
+      - name: Publish to the actual repo
+        shell: bash
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ needs.docker-build.outputs.full_image_name_remote_registry }}:${{ needs.docker-build.outputs.unique_tag }} \
+            ${{ needs.docker-build.outputs.full_image_name_local_registry }}:${{ needs.docker-build.outputs.unique_tag }}
+
+      # note that we use the digest of the local image
+      # these digests don't change after pushing, but
+      # since we deal with tags (mutable), and the way to get a digest is to use the tag, I prefer
+      # sourcing the digest from the local registry we just spun up (trusted)
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        id: attestation
+        with:
+          subject-name: ${{ needs.docker-build.outputs.full_image_name_remote_registry }}
+          subject-digest: ${{ steps.multiplatform_image.outputs.digest }}
+          push-to-registry: true
 
   all-done:
     name: All done

--- a/.github/workflows/cleanup-pr-images.yml
+++ b/.github/workflows/cleanup-pr-images.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: Cleanup PR closed, merged images
 
 on:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: "CodeQL Advanced"
 
 on:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,5 @@
-name: Prettier
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Validate formatting
 
 on:
   workflow_dispatch:
@@ -12,12 +13,9 @@ on:
 permissions:
   contents: read
 
-env:
-  NPM_CONFIG_FUND: "false"
-
 jobs:
-  prettier:
-    name: Prettier
+  format:
+    name: Format
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -43,4 +41,4 @@ jobs:
       - name: Run Prettier
         shell: bash
         run: |
-          pnpm exec prettier --check .
+          pnpm prettier --check .

--- a/.github/workflows/publish-crate-after-release.yml
+++ b/.github/workflows/publish-crate-after-release.yml
@@ -1,4 +1,6 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: Publish crate
+
 on:
   push:
     tags:
@@ -32,6 +34,9 @@ jobs:
   publish-crate:
     name: Publish crate
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
     needs:
       - repo-has-crate
     if: |
@@ -112,10 +117,13 @@ jobs:
           # debug
           cat Cargo.toml
 
+      - uses: rust-lang/crates-io-auth-action@e919bc7605cde86df457cf5b93c5e103838bd879 # v1.0.1
+        id: auth
+
       - name: Publish
         shell: bash
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           # we don't commit the version number in our codebase
           cargo publish --allow-dirty

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: Release
 
 on:

--- a/.github/workflows/retag-containers-after-push.yml
+++ b/.github/workflows/retag-containers-after-push.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: Retag containers after new push / PR
 
 on:

--- a/.github/workflows/retag-containers-after-release.yml
+++ b/.github/workflows/retag-containers-after-release.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: Update semantic tags on repo & image after release
 
 on:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: Semgrep
 
 on:

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: Test Release
 
 on:

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
+/node_modules
+/profiling
+/reports
 /target
 
-.cr-release-packages
-.cr-index
-
-node_modules/
-reports/
-profiling/
-NEXTVERSION
+# samply output
+/profile.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,10 +1,13 @@
-.git
-.mypy_cache
-.vscode/rust-prettifier-for-lldb
-CHANGELOG.md
-profiling
-reports
-src   # rust-fmt
-tests # rust-fmt
-target
-pnpm-lock.yaml
+/.git
+/.mypy_cache
+/.vscode/rust-prettifier-for-lldb
+
+/profiling
+/reports
+/src   # rust-fmt
+/tests # rust-fmt
+/target
+
+/Cargo.lock
+/CHANGELOG.md
+/pnpm-lock.yaml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "bond-rs"
-# don't change this, it's updated before an actual build by update-version.sh
 version = "0.0.0-development"
 edition = "2024"
 rust-version = "1.88.0"
 authors = ["Kristof Mattei"]
 description = "Rust seed application"
-license-file = "LICENSE"
+license = "MIT"
 categories = ["api-bindings"]
 keywords = ["bond"]
 repository = "https://github.com/kristof-mattei/bond-rs"
+include = ["src/**", "/LICENSE", "/LICENSE-*"]
 
 [lints.clippy]
 # don't stop from compiling / running

--- a/LICENSE
+++ b/LICENSE
@@ -1,29 +1,21 @@
-BSD 3-Clause License
+MIT License
 
-Copyright (c) 2021, Kristof Mattei
-All rights reserved.
+Copyright (c) 2025 Kristof Mattei
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,26 @@
 # Rust seed application
 
-It's written in Rust!
+This is a framework for building Rust applications
 
-This is a framework for building Rust applications in combination with building Docker containers and never rebuilding code on release, instead we promote existing code.
+It supports:
 
-## TODO and done
+- Building multi-platform images
+- Reusing images when merging in PRs to preserve provenance
+    - Support for tags like `pr-${PR_NUMBER}-latest` (last build on PR), `edge` (last build on `main`), `pr-${SHA_MAIN_HEAD}-${SHA_PR_HEAD}` (uniquely identifying the merge result of a PR)
+- Container attestation
+- Crate publishing
+- Release publishing
+    - Crate publishing to crates.io
+    - Container retagging to `:latest`
 
-- [x] Figure out how to deal with PRs pushing too many Docker containers<br />
-    > We only build containers on the tip of the PR, so even if you're pushing 10 commits, we'll only build one.
+## TODO
+
 - [ ] Remove old containers when the new one gets build for a PR?<br />
       Or rely on a general weekly untagged cleanup?
 - [ ] Remove PR containers when PR closed<br />
-    > API currently unavailable
-- [x] How do we deal with older containers on `main`?<br />
-    > We move tags, so we'll need to wait for the API to clean up untagged versions
+
+## License
+
+MIT, see [LICENSE](./LICENSE)
+
+`SPDX-License-Identifier: MIT`

--- a/package.json
+++ b/package.json
@@ -1,31 +1,17 @@
 {
   "name": "bond-rs",
-  "version": "0.0.0-development",
-  "description": "It's written in Rust!",
-  "main": "src/main.rs",
+  "type": "module",
   "packageManager": "pnpm@10.13.1",
-  "scripts": {
-    "format": "prettier --write ."
-  },
   "engines": {
     "node": "22.17.0",
     "pnpm": "10.13.1"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/kristof-mattei/bond-rs.git"
-  },
-  "author": "",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/kristof-mattei/bond-rs/issues"
-  },
-  "homepage": "https://github.com/kristof-mattei/bond-rs#readme",
-  "publishConfig": {
-    "access": "restricted"
+  "scripts": {
+    "format": "prettier --write ."
   },
   "devDependencies": {
     "prettier": "3.6.2",
-    "prettier-plugin-sh": "0.18.0"
+    "prettier-plugin-sh": "0.18.0",
+    "prettier-plugin-toml": "2.0.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       prettier-plugin-sh:
         specifier: 0.18.0
         version: 0.18.0(prettier@3.6.2)
+      prettier-plugin-toml:
+        specifier: 2.0.6
+        version: 2.0.6(prettier@3.6.2)
 
 packages:
 
@@ -21,11 +24,23 @@ packages:
     resolution: {integrity: sha512-Tb5wIMvBf/nLejTQ61krK644/CEMB/cpiaIFXqGApfGqO3GwcR3qnI0DbmkFVCl2OyEp8LnLX3EkucoL0+tbFg==}
     engines: {node: ^v12.20.0 || ^14.13.0 || >=16.0.0}
 
+  '@taplo/core@0.2.0':
+    resolution: {integrity: sha512-r8bl54Zj1In3QLkiW/ex694bVzpPJ9EhwqT9xkcUVODnVUGirdB1JTsmiIv0o1uwqZiwhi8xNnTOQBRQCpizrQ==}
+
+  '@taplo/lib@0.5.0':
+    resolution: {integrity: sha512-+xIqpQXJco3T+VGaTTwmhxLa51qpkQxCjRwezjFZgr+l21ExlywJFcDfTrNmL6lG6tqb0h8GyJKO3UPGPtSCWg==}
+
   prettier-plugin-sh@0.18.0:
     resolution: {integrity: sha512-cW1XL27FOJQ/qGHOW6IHwdCiNWQsAgK+feA8V6+xUTaH0cD3Mh+tFAtBvEEWvuY6hTDzRV943Fzeii+qMOh7nQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       prettier: ^3.6.0
+
+  prettier-plugin-toml@2.0.6:
+    resolution: {integrity: sha512-12N/wBuHa9jd/KVy9pRP20NMKxQfQLMseQCt66lIbLaPLItvGUcSIryE1eZZMJ7loSws6Ig3M2Elc2EreNh76w==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      prettier: ^3.0.3
 
   prettier@3.6.2:
     resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
@@ -43,11 +58,22 @@ snapshots:
 
   '@reteps/dockerfmt@0.3.6': {}
 
+  '@taplo/core@0.2.0': {}
+
+  '@taplo/lib@0.5.0':
+    dependencies:
+      '@taplo/core': 0.2.0
+
   prettier-plugin-sh@0.18.0(prettier@3.6.2):
     dependencies:
       '@reteps/dockerfmt': 0.3.6
       prettier: 3.6.2
       sh-syntax: 0.5.8
+
+  prettier-plugin-toml@2.0.6(prettier@3.6.2):
+    dependencies:
+      '@taplo/lib': 0.5.0
+      prettier: 3.6.2
 
   prettier@3.6.2: {}
 

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -11,16 +11,22 @@ export default {
     useTabs: false,
     overrides: [
         {
-            files: ["**/*.ts", "**/*.tsx"],
-            options: {
-                parser: "typescript",
-            },
-        },
-        {
-            files: ["**/*.json"],
+            files: ["*.json"],
             options: {
                 trailingComma: "none",
                 printWidth: 80,
+            },
+        },
+        {
+            files: ["*.toml"],
+            options: {
+                printWidth: 80,
+            },
+        },
+        {
+            files: ["*.ts", "*.tsx"],
+            options: {
+                parser: "typescript",
             },
         },
         {
@@ -30,11 +36,11 @@ export default {
             },
         },
         {
-            files: ["package.json", "package-lock.json"],
+            files: ["package.json"],
             options: {
                 tabWidth: 2,
             },
         },
     ],
-    plugins: ["prettier-plugin-sh"],
+    plugins: ["prettier-plugin-sh", "prettier-plugin-toml"],
 };


### PR DESCRIPTION
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 6817e2f**
- **feat: update publish defaults**
- **chore: cleanup**
- **feat: ensure formatting works**
- **feat: attest individual and multiplatform images**
- **chore(deps): update actions/attest-build-provenance action to v2.4.0**
- **chore(deps): pin registry docker tag to 1fc7de6**
- **fix: also ignore samply output**
- **fix: simplify license, use MIT license instead of BSD, simplify package.json**
- **chore: fmt**
- **chore: also format toml**
- **fix: validate toml & sh & ... formatting as part of PR process**
- **fix: ignore Cargo.lock from being formatted**
- **chore: simplify prettierconfig**
- **fix: restore package.json 2 tab width**
- **fix: reorder**
