### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -625,7 +625,7 @@ jobs:
       # since we deal with tags (mutable), and the way to get a digest is to use the tag, I prefer
       # sourcing the digest from the local registry we just spun up (trusted)
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         id: attestation
         with:
           subject-name: ${{ needs.docker-build.outputs.full_image_name_remote_registry }}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "packageManager": "pnpm@10.15.0",
   "engines": {
-    "node": "22.18.0",
+    "node": "24.7.0",
     "pnpm": "10.15.0"
   },
   "scripts": {


### PR DESCRIPTION
- **chore(deps): update returntocorp/semgrep docker tag to v1.134.0**
- **feat: write output to per-target folder, otherwise caches overwrite each other causing recompilation in the install step**
- **fix: pre-cache**
- **chore(deps): update node.js to v22.19.0**
- **chore(deps): update actions/attest-build-provenance action to v3**
- **chore: remove submodule folder**
